### PR TITLE
Add notebook template for case studies and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ You'll just need the following settings:
 
 Netlify is smart and will find your requirements.txt to do the install for you :) (ruby and the jekyll are installed too)
 You can find the build history / logs at - https://app.netlify.com/sites/the-turing-way/deploys
+
+## Content Templates
+
+Templates for certain types of content are kept in the `templates` directory.
+Templates include:
+* `case-study-template.ipynb` - a template for including interactive case studies in the book
+
+The template should be edited accordingly and moved into it's relevant chapter folder in the `content` directory.

--- a/templates/case-study-template.ipynb
+++ b/templates/case-study-template.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Case Study Template"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This file aims to reproduce the figures/results from CaseStudyName, hosted at this GitHub repo: https:github.com/user-name/casestudyname."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is figure # from the paper:\n",
+    "\n",
+    "![image-title](figures/image-name.png)\n",
+    "\n",
+    "And here is the code snippet that builds this figure from the GitHub repository:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Insert code here"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR:
* creates the `templates` directory in the repo root
* adds a basic jupyter notebook template for including interactive case studies in the jupyter book
* updates README to document this